### PR TITLE
Add sort_images_by option (can be 'date').

### DIFF
--- a/gallery.conf.default
+++ b/gallery.conf.default
@@ -13,6 +13,9 @@
 	# highlight_filename => '#highlight',
 	# rotated_dir => '.rotated',
 
+	# Can be 'date' (slower, requires Image::ExifTool and Date::Parse)
+	# sort_images_by => 'name',
+
 	# These are "landscape" not because we assume all pictures are landscape,
 	# but because we assume most monitors are landscape. That's probably not
 	# accurate in today's mobile world, though.

--- a/lib/Gallery/Controller.pm
+++ b/lib/Gallery/Controller.pm
@@ -7,7 +7,7 @@ use Mojo::Util;
 use Data::Dumper;
 use List::Util qw{shuffle first};
 
-use Gallery qw(cache_image_as_needed $config);
+use Gallery qw(cache_image_as_needed exifdate $config);
 
 my $highlight_regex = qr{^\Q$config->{highlight_filename}\E$};
 
@@ -132,13 +132,14 @@ sub render_album_page {
 				thumb => url_escape("$basepath$entry?thumb=1"),
 				link => url_escape("$basepath$entry"),
 				name => $entry,
+				date => exifdate("$album_dir/$entry"),
 			});
 		}
 	}
 	closedir $dh;
 
 	@subalbums = sort { $a->{name} cmp $b->{name} } @subalbums;
-	@images = sort { $a->{name} cmp $b->{name} } @images;
+	@images = sort { $a->{$config->{sort_images_by}} cmp $b->{$config->{sort_images_by}} } @images;
 	pop(@parent_links) if @parent_links; # don't include the current album
 	my @albums = split(/\//, $target{album});
 	my $name = (@albums ? pop(@albums) : undef);


### PR DESCRIPTION
My wife and I are both taking photos on our phones. We'd like to be
able to upload the good ones and have them displayed in chronological
order. The filenames are numbered differently, but the EXIF date tags are
pretty accurate, so I'll set sort_images_by => 'date' in our gallery. The
default behavior is unchanged.